### PR TITLE
Set Montserrat as default font for entire project

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  html {
+    font-family: 'Montserrat', ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  }
+}

--- a/src/tokens/tokens.json
+++ b/src/tokens/tokens.json
@@ -478,11 +478,11 @@
     },
     "fontFamilies": {
       "heading": {
-        "value": "Inter",
+        "value": "Montserrat",
         "type": "fontFamilies"
       },
       "body": {
-        "value": "Roboto",
+        "value": "Montserrat",
         "type": "fontFamilies"
       }
     },


### PR DESCRIPTION
## Purpose
Standardize the project's typography by setting Montserrat as the default font family for all text elements throughout the application, as requested to ensure consistent branding and design.

## Code changes
- **HTML**: Added Google Fonts preconnect links and Montserrat font import to `index.html`
- **CSS**: Updated base layer in `index.css` to set Montserrat as the primary font family with fallbacks
- **Design tokens**: Changed font family tokens in `tokens.json` from Inter/Roboto to Montserrat for both heading and body text

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5e97c51177f0498a98152e7cc3008787/swoosh-sanctuary)

👀 [Preview Link](https://5e97c51177f0498a98152e7cc3008787-swoosh-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5e97c51177f0498a98152e7cc3008787</projectId>-->
<!--<branchName>swoosh-sanctuary</branchName>-->